### PR TITLE
v4.0.5 changelog and share/open-with handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## [4.0.5] - 2026-08-19
+
+> **Patch release:** Transaction history now shows Branta merchant identity and an animated tx visualizer (wallet-signed vs network-received). Animated UR QR send/PSBT scanning is reliable at large UTXO counts. Nostr co-sign ranks relays by live fidelity, and sharing a `.share` / `.psbt` file from Files, WhatsApp, Signal, Telegram, or any other app lands on the existing Bold task instead of a duplicate Recents card or bouncing back to the sender.
+
+### Added
+- **Transaction visualizer in history details** — compact animated track in `TransactionDetailsModal`: wallet-signed flows show two keys merging (`CompactCosignTrack`); externally received txs show a single network origin (`CompactExternalTrack`); sent, consolidation, and rebalancing all use wallet origin.
+- **Branta merchant identity on transaction history** — list rows resolve stored merchant labels (theme-aware logos, verified check) for Branta-enhanced payments; `branta_verified_txs` backfill migrates older payments that predate per-txid tracking.
+- **Nostr relay fidelity telemetry** — native `TssHook` `type: "relay"` events (publish OK/fail, RTT, bulk vs critical, block/fallback) surface in JS logs with failure-always / success-throttled logging; does not move MPC %.
+- **Local scriptPubKey derivation** — `scriptPubKeyFromAddress` plus send-prepare hydration from the local UTXO DB so compact QR coins do not need a mempool round-trip for `scriptpubkey`.
+- **Incoming share URI resolver (Android)** — `IncomingShareResolver` copies `content://` shares (any provider) into cache using `DISPLAY_NAME` when the path has no `.share` / `.psbt` extension.
+
+### Changed
+- **Animated UR send QR** — shared `UREncoder` fountain stream (not sequential-only frames), 250ms frame interval, unique-fragment progress (`N of M`) instead of fountain 99% estimates; Android send scan ignores non-UR junk while assembling and no longer alerts/closes on garbage frames.
+- **PSBT UR scan progress** — same unique-fragment progress on iOS overlay and Android ZXing text; decoder is not reset by ignored frames.
+- **Send preview change path** — `resolveChangeAddressDisplayPath` looks up the QR/route change address in HD paths instead of showing this device’s next unused change index.
+- **Nostr bulk publish** — bulk set is ranked by connected + EWMA RTT + consecutive failures (not CSV order); 4s per-bulk deadline then one critical fan-out retry across non-blocked relays.
+- **Nostr attempt handshake** — subscribe delay runs *before* the publish deadline (45s publish / 55s wait) so the old 2s sleep no longer ate the 20s context.
+- **Mempool sync yields during Nostr MPC** — `SyncCoordinator.pause()` / `resume()` abort in-flight HTTP so background sync does not contend with relay publish.
+- **Share extension (iOS)** — activation matches generic file UTIs (`public.file-url`, `public.data`, `public.item`) from any share sheet; Swift still allowlists `.share` / `.psbt` only.
+
+### Fixed
+- **Android Recents: two Bold tasks after Share/Open with** — `documentLaunchMode="never"`, file VIEW filters are no longer `BROWSABLE`, and a non-root share activity forwards the intent to the existing `singleTask` instance then finishes.
+- **iOS share bounce-back to the sending app** — share extension opens `boldwallet://import-keyshare` via the responder chain and delays `completeRequest` so Files/WhatsApp/Signal/Telegram (or any share sheet) actually foreground Bold with the import password modal.
+- **Nostr co-sign `context deadline exceeded` on attempt handshake** — timeout no longer included the peer subscribe sleep; background mempool traffic paused for the session.
+- **BBMTLib CI hang on “Install jq”** — skip `apt-get update`; `jq` is already on `ubuntu-latest`, install only as fallback.
+- **Compact QR UTXOs missing scriptpubkey** — derive from address or local DB before any explorer enrich.
+
+### Technical Details
+- **Version**: `package.json` **4.0.5**; Android **`versionCode` 66** / **`versionName` 4.0.5**; iOS build **66** / **`MARKETING_VERSION` 4.0.5**.
+- **New files**: `components/TransactionVisualizer.tsx` (expanded compact tracks), `services/BrantaVerifiedBackfill.ts`, `utils/scriptPubKeyFromAddress.ts`, `utils/sendQrScan.ts`, `android/.../IncomingShareResolver.kt`.
+- **Native Nostr**: `BBMTLib/tss/nostr_attempt.go`, `nostrtransport/relay_publish.go`, `client.go`, `progress_hook.go`, `transport_progress.go`.
+- **Share handoff**: `android/.../MainActivity.kt`, `AndroidManifest.xml`, `ios/BoldWalletShareExtension/ShareViewController.swift`, `Info.plist`, `KeyshareShareStorage.swift`.
+- **CI**: `.github/workflows/bbmtlib-test.yml` jq step.
+
+---
+
 ## [4.0.4] - 2026-08-06
 
 > **Patch release:** Device RNG awareness — the wallet now surfaces a real-time assessment of each device's random number generator quality, grounded in actual hardware detection rather than assumed defaults.

--- a/__tests__/incomingFileClassifier.test.ts
+++ b/__tests__/incomingFileClassifier.test.ts
@@ -20,6 +20,24 @@ describe('incomingFileClassifier', () => {
     expect(inferFileKindFromUri('file:///tmp/a6trK1.share')).toBe('keyshare');
   });
 
+  it('infers keyshare from provider content URI displayName', () => {
+    expect(
+      inferFileKindFromUri(
+        'content://org.telegram.messenger.provider/media/42?displayName=wallet.share',
+      ),
+    ).toBe('keyshare');
+    expect(
+      inferFileKindFromUri(
+        'content://com.whatsapp.provider.media/item/7?displayName=backup.share',
+      ),
+    ).toBe('keyshare');
+    expect(
+      inferFileKindFromUri(
+        'content://com.android.externalstorage.documents/document/primary%3ADownload%2Fkey.share',
+      ),
+    ).toBe('keyshare');
+  });
+
   it('detects PSBT magic bytes', () => {
     const psbtBytes = Buffer.from([0x70, 0x73, 0x62, 0x74, 0x00]);
     expect(isPsbtBytes(psbtBytes)).toBe(true);

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:launchMode="singleTask"
+            android:documentLaunchMode="never"
             android:windowSoftInputMode="adjustResize"
             android:screenOrientation="portrait"
             android:exported="true">
@@ -34,14 +35,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="content" android:pathPattern=".*\\.share" />
                 <data android:scheme="file" android:pathPattern=".*\\.share" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="content" android:pathPattern=".*\\.psbt" />
                 <data android:scheme="file" android:pathPattern=".*\\.psbt" />
             </intent-filter>

--- a/android/app/src/main/java/com/boldwallet/IncomingShareResolver.kt
+++ b/android/app/src/main/java/com/boldwallet/IncomingShareResolver.kt
@@ -1,0 +1,96 @@
+package com.boldwallet
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.OpenableColumns
+import java.io.File
+
+/**
+ * Resolves ACTION_SEND / ACTION_VIEW content:// URIs from any app
+ * (Files, Telegram, WhatsApp, Signal, etc.). Provider paths often omit
+ * the .share / .psbt extension, so we use DISPLAY_NAME and copy to cache
+ * so JS can classify the file.
+ */
+object IncomingShareResolver {
+    private val extensionRegex = Regex("\\.(share|psbt)(?:[?#].*)?$", RegexOption.IGNORE_CASE)
+
+    fun supportedExtension(value: String?): String? {
+        if (value.isNullOrBlank()) {
+            return null
+        }
+        return extensionRegex.find(value.trim())?.groupValues?.get(1)?.lowercase()
+    }
+
+    fun queryDisplayName(context: Context, uri: Uri): String? {
+        if (uri.scheme == "file") {
+            return uri.lastPathSegment
+        }
+        return try {
+            context.contentResolver
+                .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                ?.use { cursor ->
+                    if (!cursor.moveToFirst()) {
+                        return@use uri.lastPathSegment
+                    }
+                    val idx = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (idx >= 0) cursor.getString(idx) else uri.lastPathSegment
+                }
+        } catch (_: Exception) {
+            uri.lastPathSegment
+        }
+    }
+
+    fun decorateUriWithDisplayName(uri: Uri, displayName: String?): String {
+        val raw = uri.toString()
+        if (supportedExtension(raw) != null) {
+            return raw
+        }
+        val name = displayName ?: return raw
+        if (supportedExtension(name) == null) {
+            return raw
+        }
+        val sep = if (raw.contains("?")) "&" else "?"
+        return "${raw}${sep}displayName=${Uri.encode(name)}"
+    }
+
+    fun resolveToLocalUri(context: Context, uri: Uri): String? {
+        val displayName = queryDisplayName(context, uri)
+        val ext =
+            supportedExtension(uri.toString())
+                ?: supportedExtension(displayName)
+                ?: supportedExtension(uri.lastPathSegment)
+                ?: return null
+
+        try {
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION,
+            )
+        } catch (_: Exception) {
+            // Provider may only grant a one-shot read; copy still works from the activity.
+        }
+
+        val dest = File(context.cacheDir, "incoming_shared.$ext")
+        return try {
+            if (dest.exists()) {
+                dest.delete()
+            }
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                dest.outputStream().use { output -> input.copyTo(output) }
+            }
+            if (dest.exists() && dest.length() > 0L) {
+                Uri.fromFile(dest).toString()
+            } else {
+                fallbackUri(uri, displayName)
+            }
+        } catch (_: Exception) {
+            fallbackUri(uri, displayName)
+        }
+    }
+
+    private fun fallbackUri(uri: Uri, displayName: String?): String? {
+        val decorated = decorateUriWithDisplayName(uri, displayName)
+        return if (supportedExtension(decorated) != null) decorated else null
+    }
+}

--- a/android/app/src/main/java/com/boldwallet/MainActivity.kt
+++ b/android/app/src/main/java/com/boldwallet/MainActivity.kt
@@ -11,8 +11,6 @@ import com.facebook.react.defaults.DefaultReactActivityDelegate
 
 class MainActivity : ReactActivity() {
 
-    private val sharedFileUriRegex = Regex(".*\\.(share|psbt)(?:[?#].*)?$")
-
     override fun getMainComponentName(): String = "BoldWallet"
 
     override fun createReactActivityDelegate(): ReactActivityDelegate =
@@ -20,6 +18,11 @@ class MainActivity : ReactActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(null)
+        if (!isTaskRoot) {
+            forwardIntentToExistingTask(intent)
+            finish()
+            return
+        }
         handleIncomingIntent(intent)
     }
 
@@ -27,6 +30,20 @@ class MainActivity : ReactActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         handleIncomingIntent(intent)
+    }
+
+    private fun forwardIntentToExistingTask(source: Intent?) {
+        if (source == null) {
+            return
+        }
+        val forwarded = Intent(source)
+        forwarded.setClass(this, MainActivity::class.java)
+        forwarded.addFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP,
+        )
+        startActivity(forwarded)
     }
 
     private fun handleIncomingIntent(intent: Intent?) {
@@ -71,31 +88,31 @@ class MainActivity : ReactActivity() {
     }
 
     private fun extractShareFileUri(intent: Intent): String? {
+        val uri = shareUriFromIntent(intent) ?: return null
+        return IncomingShareResolver.resolveToLocalUri(this, uri)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun shareUriFromIntent(intent: Intent): Uri? {
         when (intent.action) {
             Intent.ACTION_SEND -> {
-                val streamUri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
-                if (streamUri != null) {
-                    val uri = streamUri.toString()
-                    return if (isSupportedSharedFileUri(uri)) uri else null
-                }
-                val text = intent.getStringExtra(Intent.EXTRA_TEXT)
-                if (!text.isNullOrBlank() && (text.startsWith("content://") || text.startsWith("file://"))) {
-                    val uri = text.trim()
-                    return if (isSupportedSharedFileUri(uri)) uri else null
+                intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.let { return it }
+                intent.clipData?.takeIf { it.itemCount > 0 }?.getItemAt(0)?.uri?.let { return it }
+                val text = intent.getStringExtra(Intent.EXTRA_TEXT)?.trim()
+                if (!text.isNullOrBlank() &&
+                    (text.startsWith("content://") || text.startsWith("file://"))
+                ) {
+                    return Uri.parse(text)
                 }
             }
             Intent.ACTION_VIEW -> {
                 val data = intent.data ?: return null
                 val scheme = data.scheme?.lowercase() ?: return null
                 if (scheme == "content" || scheme == "file") {
-                    val uri = data.toString()
-                    return if (isSupportedSharedFileUri(uri)) uri else null
+                    return data
                 }
             }
         }
         return null
     }
-
-    private fun isSupportedSharedFileUri(uri: String): Boolean =
-        sharedFileUriRegex.matches(uri.lowercase())
 }

--- a/ios/BoldWalletShareExtension/Info.plist
+++ b/ios/BoldWalletShareExtension/Info.plist
@@ -25,7 +25,7 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
-			<string>SUBQUERY(extensionItems, $item, SUBQUERY($item.attachments, $attachment, (ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.reactjs.native.boldbtc.wallet.keyshare") OR (ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.reactjs.native.boldbtc.wallet.psbt")).@count &gt; 0).@count == 1</string>
+			<string>SUBQUERY(extensionItems, $item, SUBQUERY($item.attachments, $attachment, (ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.reactjs.native.boldbtc.wallet.keyshare") OR (ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.reactjs.native.boldbtc.wallet.psbt") OR (ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url") OR (ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.data") OR (ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.item")).@count &gt; 0).@count == 1</string>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.share-services</string>

--- a/ios/BoldWalletShareExtension/KeyshareShareStorage.swift
+++ b/ios/BoldWalletShareExtension/KeyshareShareStorage.swift
@@ -23,8 +23,13 @@ enum KeyshareShareStorage {
     guard let containerURL = groupContainerURL() else {
       return nil
     }
-    let destinationURL = containerURL.appendingPathComponent(pendingFileName)
+    let ext = sourceURL.pathExtension.lowercased()
+    let fileName = (ext == "psbt" || ext == "share") ? "pending_shared.\(ext)" : pendingFileName
+    let destinationURL = containerURL.appendingPathComponent(fileName)
     let fileManager = FileManager.default
+    try? fileManager.removeItem(at: containerURL.appendingPathComponent(pendingFileName))
+    try? fileManager.removeItem(at: containerURL.appendingPathComponent("pending_shared.share"))
+    try? fileManager.removeItem(at: containerURL.appendingPathComponent("pending_shared.psbt"))
     try? fileManager.removeItem(at: destinationURL)
     do {
       if sourceURL.startAccessingSecurityScopedResource() {

--- a/ios/BoldWalletShareExtension/ShareViewController.swift
+++ b/ios/BoldWalletShareExtension/ShareViewController.swift
@@ -2,6 +2,8 @@ import UIKit
 
 class ShareViewController: UIViewController {
   private let supportedExtensions: Set<String> = ["share", "psbt"]
+  private let hostHandoffURL = URL(string: "boldwallet://import-keyshare")
+  private let hostOpenDelay: TimeInterval = 0.35
 
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
@@ -23,11 +25,14 @@ class ShareViewController: UIViewController {
           "org.reactjs.native.boldbtc.wallet.keyshare",
           "org.reactjs.native.boldbtc.wallet.psbt",
           "public.file-url",
+          "public.url",
+          "public.data",
+          "public.item",
         ]
         for typeIdentifier in typeIdentifiers where provider.hasItemConformingToTypeIdentifier(typeIdentifier) {
           provider.loadItem(forTypeIdentifier: typeIdentifier, options: nil) { [weak self] item, _ in
             DispatchQueue.main.async {
-              self?.handleLoadedItem(item)
+              self?.handleLoadedItem(item, suggestedName: provider.suggestedName)
             }
           }
           return
@@ -37,10 +42,23 @@ class ShareViewController: UIViewController {
     closeExtension()
   }
 
-  private func handleLoadedItem(_ item: NSSecureCoding?) {
+  private func handleLoadedItem(_ item: NSSecureCoding?, suggestedName: String?) {
     if let url = item as? URL {
       if isSupportedSharedFile(url), KeyshareShareStorage.copyIncomingFile(at: url) != nil {
-        openHostApp()
+        openHostAppThenClose()
+        return
+      }
+    }
+    if let data = item as? Data {
+      let name = suggestedFileName(suggestedName, data: data)
+      let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+      do {
+        try data.write(to: tempURL, options: .atomic)
+        if isSupportedSharedFile(tempURL), KeyshareShareStorage.copyIncomingFile(at: tempURL) != nil {
+          openHostAppThenClose()
+          return
+        }
+      } catch {
         closeExtension()
         return
       }
@@ -48,14 +66,57 @@ class ShareViewController: UIViewController {
     closeExtension()
   }
 
+  private func suggestedFileName(_ suggestedName: String?, data: Data? = nil) -> String {
+    let name = (suggestedName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    if !name.isEmpty, isSupportedSharedFile(URL(fileURLWithPath: name)) {
+      return name
+    }
+    if let data, data.count >= 4, Array(data.prefix(4)) == [0x70, 0x73, 0x62, 0x74] {
+      return "pending_shared.psbt"
+    }
+    return "pending_keyshare.share"
+  }
+
   private func isSupportedSharedFile(_ url: URL) -> Bool {
     let ext = url.pathExtension.lowercased()
     return supportedExtensions.contains(ext)
   }
 
+  /// Share extensions cannot rely on NSExtensionContext.open. Walk the
+  /// responder chain so Files, WhatsApp, Signal, Telegram, etc. actually
+  /// foreground Bold, then dismiss after a short delay so completeRequest
+  /// does not cancel the hop.
+  private func openHostAppThenClose() {
+    openHostApp()
+    DispatchQueue.main.asyncAfter(deadline: .now() + hostOpenDelay) { [weak self] in
+      self?.closeExtension()
+    }
+  }
+
   private func openHostApp() {
-    guard let url = URL(string: "boldwallet://import-keyshare") else {
+    guard let url = hostHandoffURL else {
       return
+    }
+    var responder: UIResponder? = self
+    while let current = responder {
+      if let application = current as? UIApplication {
+        application.open(url, options: [:], completionHandler: nil)
+        return
+      }
+      responder = current.next
+    }
+    responder = self
+    let openSelector = sel_registerName("openURL:")
+    while let current = responder {
+      if current is NSExtensionContext {
+        responder = current.next
+        continue
+      }
+      if current.responds(to: openSelector) {
+        current.perform(openSelector, with: url)
+        return
+      }
+      responder = current.next
     }
     extensionContext?.open(url, completionHandler: { _ in })
   }

--- a/ios/KeyshareShareStorage.swift
+++ b/ios/KeyshareShareStorage.swift
@@ -38,8 +38,13 @@ enum KeyshareShareStorage {
     guard let containerURL = groupContainerURL() else {
       return nil
     }
-    let destinationURL = containerURL.appendingPathComponent(pendingFileName)
+    let ext = sourceURL.pathExtension.lowercased()
+    let fileName = (ext == "psbt" || ext == "share") ? "pending_shared.\(ext)" : pendingFileName
+    let destinationURL = containerURL.appendingPathComponent(fileName)
     let fileManager = FileManager.default
+    try? fileManager.removeItem(at: containerURL.appendingPathComponent(pendingFileName))
+    try? fileManager.removeItem(at: containerURL.appendingPathComponent("pending_shared.share"))
+    try? fileManager.removeItem(at: containerURL.appendingPathComponent("pending_shared.psbt"))
     try? fileManager.removeItem(at: destinationURL)
     do {
       if sourceURL.startAccessingSecurityScopedResource() {


### PR DESCRIPTION
## Summary
- Follow-up to [#78](https://github.com/BoldBitcoinWallet/BoldWallet/pull/78): prepend `CHANGELOG.md` for **v4.0.5** (2026-08-19) covering history visualizer, Branta on tx list, UR send/PSBT scanning, Nostr relay fidelity, and share-target fixes.
- Android: collapse duplicate Recents tasks (`documentLaunchMode=never`, non-root share activity forwards to the existing `singleTask`) and resolve `content://` shares from any app via `DISPLAY_NAME` + cache copy.
- iOS: share extension actually foregrounds Bold (`responder-chain openURL`, delayed `completeRequest`) and accepts generic file UTIs from Files, WhatsApp, Signal, Telegram, etc. (still allowlists `.share` / `.psbt`).

